### PR TITLE
Bug in ff_getcwd when FF_VOLUMES < 2

### DIFF
--- a/FatFs_SPI/include/f_util.h
+++ b/FatFs_SPI/include/f_util.h
@@ -1,8 +1,17 @@
 #pragma once
 #include "ff.h"
-const char *FRESULT_str(FRESULT i);
-FRESULT delete_node (
-    TCHAR* path,    /* Path name buffer with the sub-directory to delete */
-    UINT sz_buff,   /* Size of path name buffer (items) */
-    FILINFO* fno    /* Name read buffer */
-);
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+    const char *FRESULT_str(FRESULT i);
+    FRESULT delete_node (
+        TCHAR* path,    /* Path name buffer with the sub-directory to delete */
+        UINT sz_buff,   /* Size of path name buffer (items) */
+        FILINFO* fno    /* Name read buffer */
+    );
+
+#ifdef __cplusplus
+}
+#endif

--- a/FatFs_SPI/include/my_debug.h
+++ b/FatFs_SPI/include/my_debug.h
@@ -2,16 +2,25 @@
 
 #include <stdio.h>
 
-void my_printf(const char *pcFormat, ...) __attribute__((format(__printf__, 1, 2)));
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+    void my_printf(const char *pcFormat, ...) __attribute__((format(__printf__, 1, 2)));
+
+    void my_assert_func(const char *file, int line, const char *func,
+                        const char *pred);
+
+#ifdef __cplusplus
+}
+#endif
+
 
 //#if defined(DEBUG) && !defined(NDEBUG)
 #define DBG_PRINTF my_printf
 //#else
 //#define DBG_PRINTF(fmt, args...) /* Don't do anything in release builds*/
 //#endif
-
-void my_assert_func(const char *file, int line, const char *func,
-                    const char *pred);
 
 #define myASSERT(__e) \
     ((__e) ? (void)0 : my_assert_func(__FILE__, __LINE__, __func__, #__e))

--- a/FatFs_SPI/include/rtc.h
+++ b/FatFs_SPI/include/rtc.h
@@ -1,15 +1,8 @@
 #pragma once
 
-#include <time.h>
-
-#include "hardware/rtc.h"
-#include "pico/util/datetime.h"
-
 #ifdef __cplusplus
 extern "C" {
 #endif
-
-extern time_t epochtime;
 
 void time_init();
 

--- a/FatFs_SPI/include/rtc.h
+++ b/FatFs_SPI/include/rtc.h
@@ -12,8 +12,6 @@ extern "C" {
 extern time_t epochtime;
 
 void time_init();
-void setrtc(datetime_t *t);
-void update_epochtime();
 
 #ifdef __cplusplus
 }

--- a/FatFs_SPI/include/rtc.h
+++ b/FatFs_SPI/include/rtc.h
@@ -13,6 +13,7 @@ extern time_t epochtime;
 
 void time_init();
 void setrtc(datetime_t *t);
+void update_epochtime();
 
 #ifdef __cplusplus
 }

--- a/FatFs_SPI/sd_driver/hw_config.c
+++ b/FatFs_SPI/sd_driver/hw_config.c
@@ -36,7 +36,7 @@ void spi0_dma_isr();
 static spi_t spis[] = {  // One for each SPI.
     {
         .hw_inst = spi0,  // SPI component
-        .miso_gpio = 16,
+        .miso_gpio = 16, // GPIO number (not pin number)
         .mosi_gpio = 19,
         .sck_gpio = 18,
         /* The choice of SD card matters! SanDisk runs at the highest speed. PNY

--- a/FatFs_SPI/sd_driver/hw_config.c
+++ b/FatFs_SPI/sd_driver/hw_config.c
@@ -41,8 +41,8 @@ static spi_t spis[] = {  // One for each SPI.
         .sck_gpio = 18,
         /* The choice of SD card matters! SanDisk runs at the highest speed. PNY
            can only mangage 5 MHz. Those are all I've tried. */
-        .baud_rate = 5000 * 1000,
-        //.baud_rate = 12500 * 1000,  // The limitation here is SPI slew rate.
+        //.baud_rate = 1000 * 1000,
+        .baud_rate = 12500 * 1000,  // The limitation here is SPI slew rate.
         //.baud_rate = 25 * 1000 * 1000, // Actual frequency: 20833333. Has
         // worked for me with SanDisk.
 

--- a/FatFs_SPI/sd_driver/sd_card.c
+++ b/FatFs_SPI/sd_driver/sd_card.c
@@ -465,7 +465,7 @@ static int sd_cmd(sd_card_t *this, const cmdSupported cmd, uint32_t arg,
                    response);
         return SD_BLOCK_DEVICE_ERROR_NO_DEVICE;  // No device
     }
-    if (response & R1_COM_CRC_ERROR) {
+    if (response & R1_COM_CRC_ERROR && ACMD23_SET_WR_BLK_ERASE_COUNT != cmd) {
         DBG_PRINTF("CRC error CMD:%d response 0x%" PRIx32 "\n", cmd, response);
         return SD_BLOCK_DEVICE_ERROR_CRC;  // CRC error
     }

--- a/FatFs_SPI/sd_driver/sd_card.h
+++ b/FatFs_SPI/sd_driver/sd_card.h
@@ -61,13 +61,13 @@ enum {
 #endif
 
 bool sd_init_driver();
-int sd_init_card(sd_card_t *this);
-int sd_write_blocks(sd_card_t *this, const uint8_t *buffer,
+int sd_init_card(sd_card_t *pSD);
+int sd_write_blocks(sd_card_t *pSD, const uint8_t *buffer,
                     uint64_t ulSectorNumber, uint32_t blockCnt);
-int sd_read_blocks(sd_card_t *this, uint8_t *buffer, uint64_t ulSectorNumber,
+int sd_read_blocks(sd_card_t *pSD, uint8_t *buffer, uint64_t ulSectorNumber,
                    uint32_t ulSectorCount);
-bool sd_card_detect(sd_card_t *this);
-uint64_t sd_sectors(sd_card_t *this);
+bool sd_card_detect(sd_card_t *pSD);
+uint64_t sd_sectors(sd_card_t *pSD);
 
 #endif
 /* [] END OF FILE */

--- a/FatFs_SPI/sd_driver/spi.c
+++ b/FatFs_SPI/sd_driver/spi.c
@@ -18,11 +18,11 @@
 //
 #include "spi.h"
 
-void spi_irq_handler(spi_t *this) {
+void spi_irq_handler(spi_t *pSPI) {
     // Clear the interrupt request.
-    dma_hw->ints0 = 1u << this->rx_dma;
-    myASSERT(!dma_channel_is_busy(this->rx_dma));
-    sem_release(&this->sem);
+    dma_hw->ints0 = 1u << pSPI->rx_dma;
+    myASSERT(!dma_channel_is_busy(pSPI->rx_dma));
+    sem_release(&pSPI->sem);
 }
 
 // SPI Transfer: Read & Write (simultaneously) on SPI bus
@@ -31,126 +31,126 @@ void spi_irq_handler(spi_t *this) {
 //     pass NULL as tx and then the SPI_FILL_CHAR is sent out as each data
 //     element.
 
-bool spi_transfer(spi_t *this, const uint8_t *tx, uint8_t *rx, size_t length) {
+bool spi_transfer(spi_t *pSPI, const uint8_t *tx, uint8_t *rx, size_t length) {
     myASSERT(512 == length);
     myASSERT(tx || rx);
     // myASSERT(!(tx && rx));
 
     // tx write increment is already false
     if (tx) {
-        channel_config_set_read_increment(&this->tx_dma_cfg, true);
+        channel_config_set_read_increment(&pSPI->tx_dma_cfg, true);
     } else {
         static const uint8_t dummy = SPI_FILL_CHAR;
         tx = &dummy;
-        channel_config_set_read_increment(&this->tx_dma_cfg, false);
+        channel_config_set_read_increment(&pSPI->tx_dma_cfg, false);
     }
     // rx read increment is already false
     if (rx) {
-        channel_config_set_write_increment(&this->rx_dma_cfg, true);
+        channel_config_set_write_increment(&pSPI->rx_dma_cfg, true);
     } else {
         static uint8_t dummy = 0xA5;
         rx = &dummy;
-        channel_config_set_write_increment(&this->rx_dma_cfg, false);
+        channel_config_set_write_increment(&pSPI->rx_dma_cfg, false);
     }
     // Clear the interrupt request.
-    dma_hw->ints0 = 1u << this->rx_dma;
+    dma_hw->ints0 = 1u << pSPI->rx_dma;
 
-    dma_channel_configure(this->tx_dma, &this->tx_dma_cfg,
-                          &spi_get_hw(this->hw_inst)->dr,  // write address
+    dma_channel_configure(pSPI->tx_dma, &pSPI->tx_dma_cfg,
+                          &spi_get_hw(pSPI->hw_inst)->dr,  // write address
                           tx,                              // read address
                           XFER_BLOCK_SIZE,  // element count (each element is of
                                             // size transfer_data_size)
                           false);           // start
-    dma_channel_configure(this->rx_dma, &this->rx_dma_cfg,
+    dma_channel_configure(pSPI->rx_dma, &pSPI->rx_dma_cfg,
                           rx,                              // write address
-                          &spi_get_hw(this->hw_inst)->dr,  // read address
+                          &spi_get_hw(pSPI->hw_inst)->dr,  // read address
                           XFER_BLOCK_SIZE,  // element count (each element is of
                                             // size transfer_data_size)
                           false);           // start
 
     // start them exactly simultaneously to avoid races (in extreme cases
     // the FIFO could overflow)
-    dma_start_channel_mask((1u << this->tx_dma) | (1u << this->rx_dma));
+    dma_start_channel_mask((1u << pSPI->tx_dma) | (1u << pSPI->rx_dma));
 
     /* Timeout 1 sec */
     uint32_t timeOut = 1000;
     /* Wait until master completes transfer or time out has occured. */
-    bool rc = sem_acquire_timeout_ms(&this->sem, timeOut);  // Wait for notification from ISR
+    bool rc = sem_acquire_timeout_ms(&pSPI->sem, timeOut);  // Wait for notification from ISR
     if (!rc) {
         // If the timeout is reached the function will return false
         DBG_PRINTF("Notification wait timed out in %s\n", __FUNCTION__);
         return false;
     }
-    dma_channel_wait_for_finish_blocking(this->tx_dma);
-    dma_channel_wait_for_finish_blocking(this->rx_dma);
+    dma_channel_wait_for_finish_blocking(pSPI->tx_dma);
+    dma_channel_wait_for_finish_blocking(pSPI->rx_dma);
 
-    myASSERT(!dma_channel_is_busy(this->tx_dma));
-    myASSERT(!dma_channel_is_busy(this->rx_dma));
+    myASSERT(!dma_channel_is_busy(pSPI->tx_dma));
+    myASSERT(!dma_channel_is_busy(pSPI->rx_dma));
 
     return true;
 }
 
-bool my_spi_init(spi_t *this) {
+bool my_spi_init(spi_t *pSPI) {
     // bool __atomic_test_and_set (void *ptr, int memorder)
     // This built-in function performs an atomic test-and-set operation on the
     // byte at *ptr. The byte is set to some implementation defined nonzero
     // “set” value and the return value is true if and only if the previous
     // contents were “set”.
-    if (__atomic_test_and_set(&(this->initialized), __ATOMIC_SEQ_CST))
+    if (__atomic_test_and_set(&(pSPI->initialized), __ATOMIC_SEQ_CST))
         return true;
 
     // The SPI may be shared (using multiple SSs); protect it
-    sem_init(&this->sem, 0, 1); 
+    sem_init(&pSPI->sem, 0, 1); 
 
     /* Configure component */
     // Enable SPI at 100 kHz and connect to GPIOs
-    spi_init(this->hw_inst, 100 * 1000);
-    spi_set_format(this->hw_inst, 8, SPI_CPOL_0, SPI_CPHA_0, SPI_MSB_FIRST);
+    spi_init(pSPI->hw_inst, 100 * 1000);
+    spi_set_format(pSPI->hw_inst, 8, SPI_CPOL_0, SPI_CPHA_0, SPI_MSB_FIRST);
 
-    gpio_set_function(this->miso_gpio, GPIO_FUNC_SPI);
-    gpio_set_function(this->mosi_gpio, GPIO_FUNC_SPI);
-    gpio_set_function(this->sck_gpio, GPIO_FUNC_SPI);
+    gpio_set_function(pSPI->miso_gpio, GPIO_FUNC_SPI);
+    gpio_set_function(pSPI->mosi_gpio, GPIO_FUNC_SPI);
+    gpio_set_function(pSPI->sck_gpio, GPIO_FUNC_SPI);
     // ss_gpio is initialized in sd_spi_init()
 
     // SD cards' DO MUST be pulled up.
-    gpio_pull_up(this->miso_gpio);
+    gpio_pull_up(pSPI->miso_gpio);
 
     // Grab some unused dma channels
-    this->tx_dma = dma_claim_unused_channel(true);
-    this->rx_dma = dma_claim_unused_channel(true);
+    pSPI->tx_dma = dma_claim_unused_channel(true);
+    pSPI->rx_dma = dma_claim_unused_channel(true);
 
-    this->tx_dma_cfg = dma_channel_get_default_config(this->tx_dma);
-    this->rx_dma_cfg = dma_channel_get_default_config(this->rx_dma);
-    channel_config_set_transfer_data_size(&this->tx_dma_cfg, DMA_SIZE_8);
-    channel_config_set_transfer_data_size(&this->rx_dma_cfg, DMA_SIZE_8);
+    pSPI->tx_dma_cfg = dma_channel_get_default_config(pSPI->tx_dma);
+    pSPI->rx_dma_cfg = dma_channel_get_default_config(pSPI->rx_dma);
+    channel_config_set_transfer_data_size(&pSPI->tx_dma_cfg, DMA_SIZE_8);
+    channel_config_set_transfer_data_size(&pSPI->rx_dma_cfg, DMA_SIZE_8);
 
     // We set the outbound DMA to transfer from a memory buffer to the SPI
     // transmit FIFO paced by the SPI TX FIFO DREQ The default is for the
     // read address to increment every element (in this case 1 byte -
     // DMA_SIZE_8) and for the write address to remain unchanged.
-    channel_config_set_dreq(&this->tx_dma_cfg, spi_get_index(this->hw_inst)
+    channel_config_set_dreq(&pSPI->tx_dma_cfg, spi_get_index(pSPI->hw_inst)
                                                    ? DREQ_SPI1_TX
                                                    : DREQ_SPI0_TX);
-    channel_config_set_write_increment(&this->tx_dma_cfg, false);
+    channel_config_set_write_increment(&pSPI->tx_dma_cfg, false);
 
     // We set the inbound DMA to transfer from the SPI receive FIFO to a
     // memory buffer paced by the SPI RX FIFO DREQ We coinfigure the read
     // address to remain unchanged for each element, but the write address
     // to increment (so data is written throughout the buffer)
-    channel_config_set_dreq(&this->rx_dma_cfg, spi_get_index(this->hw_inst)
+    channel_config_set_dreq(&pSPI->rx_dma_cfg, spi_get_index(pSPI->hw_inst)
                                                    ? DREQ_SPI1_RX
                                                    : DREQ_SPI0_RX);
-    channel_config_set_read_increment(&this->rx_dma_cfg, false);
+    channel_config_set_read_increment(&pSPI->rx_dma_cfg, false);
 
     /* Theory: we only need an interrupt on rx complete,
     since if rx is complete, tx must also be complete. */
 
     // Configure the processor to run dma_handler() when DMA IRQ 0 is
     // asserted
-    irq_set_exclusive_handler(DMA_IRQ_0, this->dma_isr);
+    irq_set_exclusive_handler(DMA_IRQ_0, pSPI->dma_isr);
 
     // Tell the DMA to raise IRQ line 0 when the channel finishes a block
-    dma_channel_set_irq0_enabled(this->rx_dma, true);
+    dma_channel_set_irq0_enabled(pSPI->rx_dma, true);
     irq_set_enabled(DMA_IRQ_0, true);
 
     LED_INIT();

--- a/FatFs_SPI/sd_driver/spi.h
+++ b/FatFs_SPI/sd_driver/spi.h
@@ -28,7 +28,7 @@
 typedef struct {
     // SPI HW
     spi_inst_t *hw_inst;
-    const uint miso_gpio;  // SPI MISO pin number for GPIO
+    const uint miso_gpio;  // SPI MISO GPIO number (not pin number)
     const uint mosi_gpio;
     const uint sck_gpio;
     const uint baud_rate;

--- a/FatFs_SPI/sd_driver/spi.h
+++ b/FatFs_SPI/sd_driver/spi.h
@@ -42,11 +42,19 @@ typedef struct {
     semaphore_t sem;
 } spi_t;
 
-// SPI DMA interrupts
-void spi_irq_handler(spi_t *this);
+#ifdef __cplusplus
+extern "C" {
+#endif
 
-bool spi_transfer(spi_t *this, const uint8_t *tx, uint8_t *rx, size_t length);
-bool my_spi_init(spi_t *this);
+    // SPI DMA interrupts
+    void spi_irq_handler(spi_t *pSPI);
+
+    bool spi_transfer(spi_t *pSPI, const uint8_t *tx, uint8_t *rx, size_t length);
+    bool my_spi_init(spi_t *pSPI);
+
+#ifdef __cplusplus
+}
+#endif
 
 #define USE_LED 1
 #if USE_LED

--- a/FatFs_SPI/src/glue.c
+++ b/FatFs_SPI/src/glue.c
@@ -28,7 +28,7 @@ DSTATUS disk_status(BYTE pdrv /* Physical drive nmuber to identify the drive */
     TRACE_PRINTF(">>> %s\n", __FUNCTION__);
     sd_card_t *p_sd = sd_get_by_num(pdrv);
     if (!p_sd) return RES_PARERR;
-    return sd_init_card(p_sd);
+    return p_sd->m_Status; // See http://elm-chan.org/fsw/ff/doc/dstat.html
 }
 
 /*-----------------------------------------------------------------------*/
@@ -41,7 +41,7 @@ DSTATUS disk_initialize(
     TRACE_PRINTF(">>> %s\n", __FUNCTION__);
     sd_card_t *p_sd = sd_get_by_num(pdrv);
     if (!p_sd) return RES_PARERR;
-    return sd_init_card(p_sd);
+    return sd_init_card(p_sd); // See http://elm-chan.org/fsw/ff/doc/dstat.html
 }
 
 static int sdrc2dresult(int sd_rc) {

--- a/FatFs_SPI/src/rtc.c
+++ b/FatFs_SPI/src/rtc.c
@@ -12,6 +12,7 @@
 
 time_t epochtime;
 
+// Make an attempt to save a recent time stamp across reset:
 typedef struct rtc_save {
     uint32_t signature;
     datetime_t datetime;
@@ -19,7 +20,7 @@ typedef struct rtc_save {
 } rtc_save_t;
 static rtc_save_t rtc_save __attribute__((section(".uninitialized_data")));
 
-void update_epochtime() {
+static void update_epochtime() {
     bool rc = rtc_get_datetime(&rtc_save.datetime);
     if (rc) {
         rtc_save.signature = 0xBABEBABE;
@@ -44,6 +45,7 @@ void update_epochtime() {
 }
 
 time_t time(time_t *pxTime) {
+    update_epochtime();
     if (pxTime) {
         *pxTime = epochtime;
     }

--- a/FatFs_SPI/src/rtc.c
+++ b/FatFs_SPI/src/rtc.c
@@ -1,4 +1,5 @@
 #include <stdio.h>
+#include <time.h>
 //
 #include "hardware/rtc.h"
 #include "pico/stdio.h"
@@ -10,7 +11,7 @@
 //
 #include "rtc.h"
 
-time_t epochtime;
+static time_t epochtime;
 
 // Make an attempt to save a recent time stamp across reset:
 typedef struct rtc_save {

--- a/README.md
+++ b/README.md
@@ -182,6 +182,7 @@ You can swap the commenting to enable tracing of what's happening in that file.
   * f_read - Read data from the file
   * f_close - Close an open file
   * f_unmount
+    * There is a simple example in the `simple_example` subdirectory.
 * There is also POSIX-like API wrapper layer in `ff_stdio.h` and `ff_stdio.c`, written for compatibility with [FreeRTOS+FAT API](https://www.freertos.org/FreeRTOS-Plus/FreeRTOS_Plus_FAT/index.html) (mainly so that I could reuse some tests from that environment.)
 
 ## Next Steps

--- a/README.md
+++ b/README.md
@@ -174,7 +174,7 @@ You can swap the commenting to enable tracing of what's happening in that file.
 * Logic analyzer: for less than ten bucks, something like this [Comidox 1Set USB Logic Analyzer Device Set USB Cable 24MHz 8CH 24MHz 8 Channel UART IIC SPI Debug for Arduino ARM FPGA M100 Hot](https://smile.amazon.com/gp/product/B07KW445DJ/) and [PulseView - sigrok](https://sigrok.org/) make a nice combination for looking at SPI, as long as you don't run the baud rate too high. 
 
 ## Using the Application Programming Interface
-* After `stdio_init_all();`, `time_init();`, and whatever other Pico SDK initialization is required, call `sd_init_driver();` to initialize the SPI block device driver. 
+<strike>After `stdio_init_all();`, `time_init();`, and whatever other Pico SDK initialization is required, call `sd_init_driver();` to initialize the SPI block device driver.</strike> \[sd_init_driver() is now called implicitly.\]
 * Now, you can start using the [FatFs Application Interface](http://elm-chan.org/fsw/ff/00index_e.html). Typically,
   * f_mount - Register/Unregister the work area of the volume
   * f_open - Open/Create a file

--- a/example/CMakeLists.txt
+++ b/example/CMakeLists.txt
@@ -15,7 +15,7 @@ add_subdirectory(../FatFs_SPI build)
 
 # Add executable. Default name is the project name, version 0.1
 add_executable(FatFS_SPI_example 
-    FatFS_SPI_example.c 
+    FatFS_SPI_example.cpp 
     data_log_demo.c
     tests/simple.c
     tests/app4-IO_module_function_checker.c

--- a/example/CMakeLists.txt
+++ b/example/CMakeLists.txt
@@ -35,6 +35,8 @@ target_compile_definitions(FatFS_SPI_example PUBLIC DEBUG N_SD_CARDS=${N_SD_CARD
 pico_set_program_name(FatFS_SPI_example "FatFS_SPI_example")
 pico_set_program_version(FatFS_SPI_example "0.1")
 
+# See 4.1. Serial input and output on Raspberry Pi Pico in Getting started with Raspberry Pi Pico (https://datasheets.raspberrypi.org/pico/getting-started-with-pico.pdf)
+# and 2.7.1. Standard Input/Output (stdio) Support in Raspberry Pi Pico C/C++ SDK (https://datasheets.raspberrypi.org/pico/raspberry-pi-pico-c-sdk.pdf):
 pico_enable_stdio_uart(FatFS_SPI_example 1)
 pico_enable_stdio_usb(FatFS_SPI_example 0)
 

--- a/example/FatFS_SPI_example.c
+++ b/example/FatFS_SPI_example.c
@@ -472,7 +472,7 @@ int main() {
     stdio_init_all();
     time_init();
     adc_init();
-    sd_init_driver();
+    // sd_init_driver(); // now called from sd_init_card
 
     printf("\033[2J\033[H");  // Clear Screen
     printf("\n> ");

--- a/example/FatFS_SPI_example.c
+++ b/example/FatFS_SPI_example.c
@@ -6,6 +6,7 @@
 #include <time.h>
 //
 #include "hardware/adc.h"
+#include "hardware/rtc.h"
 #include "pico/stdlib.h"
 //
 #include "f_util.h"

--- a/example/FatFS_SPI_example.c
+++ b/example/FatFS_SPI_example.c
@@ -477,13 +477,7 @@ int main() {
     printf("\n> ");
     stdio_flush();
 
-    absolute_time_t next_epoch_update_time = get_absolute_time();
-
     for (;;) {  // Super Loop
-        if (absolute_time_diff_us(get_absolute_time(), next_epoch_update_time) < 0) {
-            update_epochtime();
-            next_epoch_update_time = delayed_by_ms(next_epoch_update_time, 1000);
-        }
         if (logger_enabled && absolute_time_diff_us(get_absolute_time(), next_log_time) < 0) {
             if (!process_logger()) logger_enabled = false;
             next_log_time = delayed_by_ms(next_log_time, period);

--- a/simple_example/CMakeLists.txt
+++ b/simple_example/CMakeLists.txt
@@ -1,0 +1,50 @@
+# Generated Cmake Pico project file
+
+cmake_minimum_required(VERSION 3.13)
+
+set(CMAKE_C_STANDARD 11)
+set(CMAKE_CXX_STANDARD 17)
+
+# initalize pico_sdk from installed location
+# (note this can come from environment, CMake cache etc)
+set(PICO_SDK_PATH "/home/carlk/pi/pico/pico-sdk")
+
+# Pull in Raspberry Pi Pico SDK (must be before project)
+include(pico_sdk_import.cmake)
+
+project(simple_example C CXX ASM)
+
+# Initialise the Raspberry Pi Pico SDK
+pico_sdk_init()
+
+add_subdirectory(../FatFs_SPI build)
+
+# Add executable. Default name is the project name, version 0.1
+add_executable(simple_example simple_example.cpp )
+
+pico_set_program_name(simple_example "simple_example")
+pico_set_program_version(simple_example "0.1")
+
+# Choose source and destination for standard input and output:
+#   See 4.1. Serial input and output on Raspberry Pi Pico in Getting started with Raspberry Pi Pico (https://datasheets.raspberrypi.org/pico/getting-started-with-pico.pdf)
+#   and 2.7.1. Standard Input/Output (stdio) Support in Raspberry Pi Pico C/C++ SDK (https://datasheets.raspberrypi.org/pico/raspberry-pi-pico-c-sdk.pdf):
+pico_enable_stdio_uart(simple_example 1)
+pico_enable_stdio_usb(simple_example 1)
+
+# Add the standard library and FatFS/SPI to the build
+target_link_libraries(simple_example 
+    pico_stdlib
+    FatFs_SPI
+)
+
+# Get number of SD cards from the environment, else set to 1:
+#   In Visual Studio this can be set in .vscode/settings.json. E.g.:
+#      "cmake.configureArgs": ["-DN_SD_CARDS=2"],
+IF (NOT DEFINED N_SD_CARDS)
+    SET(N_SD_CARDS 1)
+ENDIF()
+# Set DEBUG and N_SD_CARDS compile definitions:
+target_compile_definitions(simple_example PUBLIC DEBUG=1 N_SD_CARDS=${N_SD_CARDS})
+
+pico_add_extra_outputs(simple_example)
+

--- a/simple_example/pico_sdk_import.cmake
+++ b/simple_example/pico_sdk_import.cmake
@@ -1,0 +1,62 @@
+# This is a copy of <PICO_SDK_PATH>/external/pico_sdk_import.cmake
+
+# This can be dropped into an external project to help locate this SDK
+# It should be include()ed prior to project()
+
+if (DEFINED ENV{PICO_SDK_PATH} AND (NOT PICO_SDK_PATH))
+    set(PICO_SDK_PATH $ENV{PICO_SDK_PATH})
+    message("Using PICO_SDK_PATH from environment ('${PICO_SDK_PATH}')")
+endif ()
+
+if (DEFINED ENV{PICO_SDK_FETCH_FROM_GIT} AND (NOT PICO_SDK_FETCH_FROM_GIT))
+    set(PICO_SDK_FETCH_FROM_GIT $ENV{PICO_SDK_FETCH_FROM_GIT})
+    message("Using PICO_SDK_FETCH_FROM_GIT from environment ('${PICO_SDK_FETCH_FROM_GIT}')")
+endif ()
+
+if (DEFINED ENV{PICO_SDK_FETCH_FROM_GIT_PATH} AND (NOT PICO_SDK_FETCH_FROM_GIT_PATH))
+    set(PICO_SDK_FETCH_FROM_GIT_PATH $ENV{PICO_SDK_FETCH_FROM_GIT_PATH})
+    message("Using PICO_SDK_FETCH_FROM_GIT_PATH from environment ('${PICO_SDK_FETCH_FROM_GIT_PATH}')")
+endif ()
+
+set(PICO_SDK_PATH "${PICO_SDK_PATH}" CACHE PATH "Path to the Raspberry Pi Pico SDK")
+set(PICO_SDK_FETCH_FROM_GIT "${PICO_SDK_FETCH_FROM_GIT}" CACHE BOOL "Set to ON to fetch copy of SDK from git if not otherwise locatable")
+set(PICO_SDK_FETCH_FROM_GIT_PATH "${PICO_SDK_FETCH_FROM_GIT_PATH}" CACHE FILEPATH "location to download SDK")
+
+if (NOT PICO_SDK_PATH)
+    if (PICO_SDK_FETCH_FROM_GIT)
+        include(FetchContent)
+        set(FETCHCONTENT_BASE_DIR_SAVE ${FETCHCONTENT_BASE_DIR})
+        if (PICO_SDK_FETCH_FROM_GIT_PATH)
+            get_filename_component(FETCHCONTENT_BASE_DIR "${PICO_SDK_FETCH_FROM_GIT_PATH}" REALPATH BASE_DIR "${CMAKE_SOURCE_DIR}")
+        endif ()
+        FetchContent_Declare(
+                pico_sdk
+                GIT_REPOSITORY https://github.com/raspberrypi/pico-sdk
+                GIT_TAG master
+        )
+        if (NOT pico_sdk)
+            message("Downloading Raspberry Pi Pico SDK")
+            FetchContent_Populate(pico_sdk)
+            set(PICO_SDK_PATH ${pico_sdk_SOURCE_DIR})
+        endif ()
+        set(FETCHCONTENT_BASE_DIR ${FETCHCONTENT_BASE_DIR_SAVE})
+    else ()
+        message(FATAL_ERROR
+                "SDK location was not specified. Please set PICO_SDK_PATH or set PICO_SDK_FETCH_FROM_GIT to on to fetch from git."
+                )
+    endif ()
+endif ()
+
+get_filename_component(PICO_SDK_PATH "${PICO_SDK_PATH}" REALPATH BASE_DIR "${CMAKE_BINARY_DIR}")
+if (NOT EXISTS ${PICO_SDK_PATH})
+    message(FATAL_ERROR "Directory '${PICO_SDK_PATH}' not found")
+endif ()
+
+set(PICO_SDK_INIT_CMAKE_FILE ${PICO_SDK_PATH}/pico_sdk_init.cmake)
+if (NOT EXISTS ${PICO_SDK_INIT_CMAKE_FILE})
+    message(FATAL_ERROR "Directory '${PICO_SDK_PATH}' does not appear to contain the Raspberry Pi Pico SDK")
+endif ()
+
+set(PICO_SDK_PATH ${PICO_SDK_PATH} CACHE PATH "Path to the Raspberry Pi Pico SDK" FORCE)
+
+include(${PICO_SDK_INIT_CMAKE_FILE})

--- a/simple_example/simple_example.cpp
+++ b/simple_example/simple_example.cpp
@@ -1,0 +1,33 @@
+#include <stdio.h>
+#include "pico/stdlib.h"
+
+#include "ff.h"
+#include "f_util.h"
+#include "rtc.h"
+
+int main() {
+    stdio_init_all();
+    time_init();
+
+    puts("Hello, world!");
+
+    // See FatFs - Generic FAT Filesystem Module, "Application Interface", http://elm-chan.org/fsw/ff/00index_e.html
+    static FATFS fatfs;
+    FRESULT fr = f_mount(&fatfs, "", 1); 
+    if (FR_OK != fr) panic("f_mount error: %s (%d)\n", FRESULT_str(fr), fr);
+    FIL fil;
+    const char * const filename = "filename.txt";
+    fr = f_open(&fil, filename, FA_OPEN_APPEND | FA_WRITE);
+    if (FR_OK != fr && FR_EXIST != fr) panic("f_open(%s) error: %s (%d)\n", filename, FRESULT_str(fr), fr);
+    if (f_printf(&fil, "Hello, world!\n") < 0) {
+        printf("f_printf failed\n");
+    }
+    fr = f_close(&fil);
+    if (FR_OK != fr) {
+        printf("f_close error: %s (%d)\n", FRESULT_str(fr), fr);
+    }
+    f_unmount("");
+
+    puts("Goodbye, world!");
+    for (;;);
+}


### PR DESCRIPTION
When FF_VOLUMES >= 2, a heading drive prefix is added to the path name. ff_getcwd strips off this prefix. However, see https://github.com/carlk3/no-OS-FatFS-SD-SPI-RPi-Pico/commit/8126ebead8469b843a7ba54c957a1c34ae7a677d#r52195301
If there is no prefix, ff_getcwd failed to copy the cwd string to the buffer pointed to by pcBuffer.