### PR TITLE
Pin IRQ handlers to RAM

### DIFF
--- a/FatFs_SPI/sd_driver/spi.h
+++ b/FatFs_SPI/sd_driver/spi.h
@@ -49,9 +49,9 @@ extern "C" {
 #endif
 
 // SPI DMA interrupts
-void spi_irq_handler(spi_t *pSPI);
+void __not_in_flash_func(spi_irq_handler)(spi_t *pSPI);
 
-bool spi_transfer(spi_t *pSPI, const uint8_t *tx, uint8_t *rx, size_t length);
+bool __not_in_flash_func(spi_transfer)(spi_t *pSPI, const uint8_t *tx, uint8_t *rx, size_t length);
 bool my_spi_init(spi_t *pSPI);
 void set_spi_dma_irq_channel(bool useChannel1, bool shared);
 


### PR DESCRIPTION
There are some issues with the PicoDVI library, if the IRQ handlers execute from flash memory rather than RAM.
The 2 routines in question are defined in spi.h :

void spi_irq_handler(spi_t *pSPI);
bool spi_transfer(spi_t *pSPI, const uint8_t *tx, uint8_t *rx, size_t length);

Please could they be pinned to RAM:

void __not_in_flash_func(spi_irq_handler)(spi_t *pSPI);
bool __not_in_flash_func(spi_transfer)(spi_t *pSPI, const uint8_t *tx, uint8_t *rx, size_t length);