### PR TITLE
Use uint8_t instead of u_int8_t.

### DIFF
--- a/FatFs_SPI/sd_driver/sd_spi.c
+++ b/FatFs_SPI/sd_driver/sd_spi.c
@@ -88,7 +88,7 @@ bool sd_spi_transfer(sd_card_t *pSD, const uint8_t *tx, uint8_t *rx,
 
 uint8_t sd_spi_write(sd_card_t *pSD, const uint8_t value) {
     // TRACE_PRINTF("%s\n", __FUNCTION__);
-    u_int8_t received = SPI_FILL_CHAR;
+    uint8_t received = SPI_FILL_CHAR;
 #if 0
     int num = spi_write_read_blocking(pSD->spi->hw_inst, &value, &received, 1);    
     myASSERT(1 == num);


### PR DESCRIPTION
I am doing remote development for a client. On my local machine `u_int8_t` is available without needing to `#include` `sys/types.h` directly. However on my remote machine, building firmware fails with a `error: unknown type name 'u_int8_t'; did you mean 'uint8_t'?` error from this library.

Changing `u_int8_t` to `uint8_t` fixes the error on my remote machine, and I figured I'd open a PR, assuming this was an oversight that happens to work most of the time :P?