### PR TITLE
Added sd_test_com() which can be used to quickly test the presence of SD card when card detect is not used

### DIFF
--- a/FatFs_SPI/sd_driver/sd_card.h
+++ b/FatFs_SPI/sd_driver/sd_card.h
@@ -1,18 +1,18 @@
 /* sd_card.h
 Copyright 2021 Carl John Kugler III
 
-Licensed under the Apache License, Version 2.0 (the License); you may not use 
-this file except in compliance with the License. You may obtain a copy of the 
+Licensed under the Apache License, Version 2.0 (the License); you may not use
+this file except in compliance with the License. You may obtain a copy of the
 License at
 
-   http://www.apache.org/licenses/LICENSE-2.0 
-Unless required by applicable law or agreed to in writing, software distributed 
-under the License is distributed on an AS IS BASIS, WITHOUT WARRANTIES OR 
-CONDITIONS OF ANY KIND, either express or implied. See the License for the 
+   http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software distributed
+under the License is distributed on an AS IS BASIS, WITHOUT WARRANTIES OR
+CONDITIONS OF ANY KIND, either express or implied. See the License for the
 specific language governing permissions and limitations under the License.
 */
 
-// Note: The model used here is one FatFS per SD card. 
+// Note: The model used here is one FatFS per SD card.
 // Multiple partitions on a card are not supported.
 
 #pragma once
@@ -85,6 +85,10 @@ struct sd_card_t {
 
 bool sd_card_detect(sd_card_t *pSD);
 uint64_t sd_sectors(sd_card_t *pSD);
+
+// Useful when use_card_detect is false - call periodically to check for presence of SD card
+// Returns true if and only if SD card responded to a test command
+bool sd_test_com(sd_card_t *pSD, uint32_t timeoutMs);
 
 bool sd_init_driver();
 bool sd_card_detect(sd_card_t *sd_card_p);


### PR DESCRIPTION
I submit this as a suggestion in order to accommodate the use-case where card detect cannot be used but hot-swap of SD card is still desired. In my tests, sd_test_com() worked well with a timeout of 50 ms to quickly poll for the presence of SD card. This was necessary because sd_init() would block for a second or more while no SD card is inserted, so I couldn't use that while waiting for insertion.