### PR TITLE
Another interrupt handling bug fixed

### DIFF
--- a/FatFs_SPI/include/my_debug.h
+++ b/FatFs_SPI/include/my_debug.h
@@ -29,11 +29,15 @@ extern "C" {
 #endif
 
 
-//#if defined(DEBUG) && !defined(NDEBUG)
-#define DBG_PRINTF my_printf
-//#else
-//#define DBG_PRINTF(fmt, args...) /* Don't do anything in release builds*/
-//#endif
+#ifdef NDEBUG           /* required by ANSI standard */
+# define DBG_PRINTF(fmt, args...) {} /* Don't do anything in release builds*/
+#else
+# define DBG_PRINTF my_printf
+#endif
 
-#define myASSERT(__e) \
+#ifdef NDEBUG           /* required by ANSI standard */
+# define myASSERT(__e) ((void)0)
+#else
+# define myASSERT(__e) \
     ((__e) ? (void)0 : my_assert_func(__FILE__, __LINE__, __func__, #__e))
+#endif

--- a/FatFs_SPI/sd_driver/sd_spi.c
+++ b/FatFs_SPI/sd_driver/sd_spi.c
@@ -27,6 +27,9 @@ specific language governing permissions and limitations under the License.
 #define TRACE_PRINTF(fmt, args...)
 /* #define TRACE_PRINTF printf  // task_printf */
 
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wunused-variable"
+
 void sd_spi_go_high_frequency(sd_card_t *pSD) {
     uint actual = spi_set_baudrate(pSD->spi->hw_inst, pSD->spi->baud_rate);
     TRACE_PRINTF("%s: Actual frequency: %lu\n", __FUNCTION__, (long)actual);
@@ -35,6 +38,8 @@ void sd_spi_go_low_frequency(sd_card_t *pSD) {
     uint actual = spi_set_baudrate(pSD->spi->hw_inst, 400 * 1000); // Actual frequency: 398089
     TRACE_PRINTF("%s: Actual frequency: %lu\n", __FUNCTION__, (long)actual);
 }
+
+#pragma GCC diagnostic pop
 
 static void sd_spi_lock(sd_card_t *pSD) {
     spi_lock(pSD->spi);

--- a/FatFs_SPI/sd_driver/spi.c
+++ b/FatFs_SPI/sd_driver/spi.c
@@ -26,8 +26,11 @@ specific language governing permissions and limitations under the License.
 static bool irqChannel1 = false;
 static bool irqShared = true;
 
-#define DBG_ASSERT(p) \
-if (!p) __asm volatile ("bkpt 10");
+static inline void dbg_assert(bool p) {
+#if !defined(NDEBUG)
+    if (!p) __asm volatile("bkpt 10");
+#endif
+}
 
 static void in_spi_irq_handler(const uint DMA_IRQ_num, io_rw_32 *dma_hw_ints_p) {
     for (size_t i = 0; i < spi_get_num(); ++i) {
@@ -36,8 +39,8 @@ static void in_spi_irq_handler(const uint DMA_IRQ_num, io_rw_32 *dma_hw_ints_p) 
             // Is the SPI's channel requesting interrupt?
             if (*dma_hw_ints_p & (1 << spi_p->rx_dma)) {
                 *dma_hw_ints_p = 1 << spi_p->rx_dma;  // Clear it.
-                DBG_ASSERT(!dma_channel_is_busy(spi_p->rx_dma));
-                DBG_ASSERT(!sem_available(&spi_p->sem));
+                dbg_assert(!dma_channel_is_busy(spi_p->rx_dma));
+                dbg_assert(!sem_available(&spi_p->sem));
                 sem_release(&spi_p->sem);
             }
         }

--- a/FatFs_SPI/sd_driver/spi.c
+++ b/FatFs_SPI/sd_driver/spi.c
@@ -41,18 +41,16 @@ static void in_spi_irq_handler(const uint DMA_IRQ_num, io_rw_32 *dma_hw_ints_p) 
                 *dma_hw_ints_p = 1 << spi_p->rx_dma;  // Clear it.
                 dbg_assert(!dma_channel_is_busy(spi_p->rx_dma));
                 dbg_assert(!sem_available(&spi_p->sem));
-                sem_release(&spi_p->sem);
+                bool ok = sem_release(&spi_p->sem);
+                dbg_assert(ok);
             }
         }
     }
 }
-
 static void __not_in_flash_func(spi_irq_handler_0)() {
-    // Check DMA_IRQ_0:
     in_spi_irq_handler(DMA_IRQ_0, &dma_hw->ints0);
 }
 static void __not_in_flash_func(spi_irq_handler_1)() {
-    // Check DMA_IRQ_1:
     in_spi_irq_handler(DMA_IRQ_1, &dma_hw->ints1);
 }
 
@@ -88,8 +86,6 @@ bool spi_transfer(spi_t *spi_p, const uint8_t *tx, uint8_t *rx, size_t length) {
         rx = &dummy;
         channel_config_set_write_increment(&spi_p->rx_dma_cfg, false);
     }
-    // Clear the interrupt request.
-    dma_hw->ints0 = 1u << spi_p->rx_dma;
 
     dma_channel_configure(spi_p->tx_dma, &spi_p->tx_dma_cfg,
                           &spi_get_hw(spi_p->hw_inst)->dr,  // write address
@@ -104,7 +100,17 @@ bool spi_transfer(spi_t *spi_p, const uint8_t *tx, uint8_t *rx, size_t length) {
                                    // size transfer_data_size)
                           false);  // start
 
-    myASSERT(!sem_available(&spi_p->sem));    
+    switch (spi_p->DMA_IRQ_num) {
+        case DMA_IRQ_0:
+            myASSERT(!dma_channel_get_irq0_status(spi_p->rx_dma));
+            break;
+        case DMA_IRQ_1:
+            myASSERT(!dma_channel_get_irq1_status(spi_p->rx_dma));
+            break;
+        default:
+            myASSERT(false);
+    }
+    sem_reset(&spi_p->sem, 0);
 
     // start them exactly simultaneously to avoid races (in extreme cases
     // the FIFO could overflow)
@@ -123,6 +129,7 @@ bool spi_transfer(spi_t *spi_p, const uint8_t *tx, uint8_t *rx, size_t length) {
     dma_channel_wait_for_finish_blocking(spi_p->tx_dma);
     dma_channel_wait_for_finish_blocking(spi_p->rx_dma);
 
+    myASSERT(!sem_available(&spi_p->sem));
     myASSERT(!dma_channel_is_busy(spi_p->tx_dma));
     myASSERT(!dma_channel_is_busy(spi_p->rx_dma));
 
@@ -148,6 +155,9 @@ bool my_spi_init(spi_t *spi_p) {
         if (!mutex_is_initialized(&spi_p->mutex)) mutex_init(&spi_p->mutex);
         spi_lock(spi_p);
 
+        // Default:
+        if (!spi_p->baud_rate)
+            spi_p->baud_rate = 10 * 1000 * 1000;
         // For the IRQ notification:
         sem_init(&spi_p->sem, 0, 1);
 
@@ -218,10 +228,12 @@ bool my_spi_init(spi_t *spi_p) {
         case DMA_IRQ_0:
             spi_irq_handler_p = spi_irq_handler_0;
             dma_channel_set_irq0_enabled(spi_p->rx_dma, true);
+            dma_channel_set_irq0_enabled(spi_p->tx_dma, false);
         break;
         case DMA_IRQ_1:
             spi_irq_handler_p = spi_irq_handler_1;
             dma_channel_set_irq1_enabled(spi_p->rx_dma, true);
+            dma_channel_set_irq1_enabled(spi_p->tx_dma, false);
         break;
         default:
             myASSERT(false);


### PR DESCRIPTION
Specifically, this line in `spi_transfer`:
```
    // Clear the interrupt request.
    dma_hw->ints0 = 1u << spi_p->rx_dma;
```
must have been left over from a past when DMA_IRQ_0 was assumed.