### PR TITLE
os type define moved to config

### DIFF
--- a/FatFs_SPI/ff15/source/ffconf.h
+++ b/FatFs_SPI/ff15/source/ffconf.h
@@ -291,6 +291,8 @@
 /  The FF_FS_TIMEOUT defines timeout period in unit of O/S time tick.
 */
 
+/* 0:Win32, 1:uITRON4.0, 2:uC/OS-II, 3:FreeRTOS, 4:CMSIS-RTOS */
+#define OS_TYPE	        3
 
 
 /*--- End of configuration options ---*/

--- a/FatFs_SPI/ff15/source/ffsystem.c
+++ b/FatFs_SPI/ff15/source/ffsystem.c
@@ -39,9 +39,6 @@ void ff_memfree (
 /* Definitions of Mutex                                                   */
 /*------------------------------------------------------------------------*/
 
-#define OS_TYPE	0	/* 0:Win32, 1:uITRON4.0, 2:uC/OS-II, 3:FreeRTOS, 4:CMSIS-RTOS */
-
-
 #if   OS_TYPE == 0	/* Win32 */
 #include <windows.h>
 static HANDLE Mutex[FF_VOLUMES + 1];	/* Table of mutex handle */


### PR DESCRIPTION
I don't know if it'll be accepted (as it changes FatFS code), but it seems highly logical.

If you don't want to touch FatFS, just close it ;)