### PR TITLE
Disable drive activity LED by default

### DIFF
--- a/examples/command_line/CMakeLists.txt
+++ b/examples/command_line/CMakeLists.txt
@@ -37,6 +37,11 @@ target_compile_options(command_line PUBLIC -Wall -Wextra -Wno-unused-parameter -
 # add_compile_definitions(USE_PRINTF USE_DBG_PRINTF)
 add_compile_definitions(USE_PRINTF)
 
+# Use Pico's LED to show drive activity. 
+# Ensure that PICO_DEFAULT_LED_PIN is set correctly.
+# Note that Pico W uses GPIO 25 for SPI communication to the CYW43439.
+# add_compile_definitions(USE_LED=1)
+
 # target_compile_definitions(<TARGET> PRIVATE PARAM_ASSERTIONS_ENABLE_ALL=1)
 add_compile_definitions(PARAM_ASSERTIONS_ENABLE_ALL=1)
 

--- a/src/sd_driver/SPI/sd_card_spi.c
+++ b/src/sd_driver/SPI/sd_card_spi.c
@@ -168,20 +168,15 @@
 static bool crc_on = true;
 #endif
 
-//#define DBG_PRINTF printf
-
 #define TRACE_PRINTF(fmt, args...)
 //#define TRACE_PRINTF printf  // task_printf
-
-//#define assert configASSERT
 
 /* Control Tokens   */
 #define SPI_DATA_RESPONSE_MASK (0x1F)
 #define SPI_DATA_ACCEPTED (0x05)
 #define SPI_DATA_CRC_ERROR (0x0B)
 #define SPI_DATA_WRITE_ERROR (0x0D)
-#define SPI_START_BLOCK \
-    (0xFE)                             /*!< For Single Block Read/Write and Multiple Block Read */
+#define SPI_START_BLOCK (0xFE)         /*!< For Single Block Read/Write and Multiple Block Read */
 #define SPI_START_BLK_MUL_WRITE (0xFC) /*!< Start Multi-block write */
 #define SPI_STOP_TRAN (0xFD)           /*!< Stop Multi-block write */
 

--- a/src/sd_driver/SPI/spi.h
+++ b/src/sd_driver/SPI/spi.h
@@ -76,19 +76,23 @@ void set_spi_dma_irq_channel(bool useChannel1, bool shared);
 }
 #endif
 
-#ifndef NO_PICO_LED
-#  define USE_LED 1
-#endif
+/* 
+This uses the Pico LED to show SD card activity.
+You can use it to get a rough idea of utilization.
+Warning: Pico W uses GPIO 25 for SPI communication to the CYW43439.
 
-#if USE_LED
-#  define LED_PIN 25
+You can enable this by putting something like
+    add_compile_definitions(USE_LED=1)
+in CMakeLists.txt, for example.
+*/
+#if !defined(NO_PICO_LED) && defined(USE_LED) && USE_LED && defined(PICO_DEFAULT_LED_PIN)
 #  define LED_INIT()                     \
     {                                    \
-        gpio_init(LED_PIN);              \
-        gpio_set_dir(LED_PIN, GPIO_OUT); \
+        gpio_init(PICO_DEFAULT_LED_PIN);              \
+        gpio_set_dir(PICO_DEFAULT_LED_PIN, GPIO_OUT); \
     }
-#  define LED_ON() gpio_put(LED_PIN, 1)
-#  define LED_OFF() gpio_put(LED_PIN, 0)
+#  define LED_ON() gpio_put(PICO_DEFAULT_LED_PIN, 1)
+#  define LED_OFF() gpio_put(PICO_DEFAULT_LED_PIN, 0)
 #else
 #  define LED_ON()
 #  define LED_OFF()


### PR DESCRIPTION
For compatibility with Pico W, disable use of Pico LED by default.

The W uses GPIO 25 for SPI communication to the CYW43439.  In the old days, the Pico default LED pin (`PICO_DEFAULT_LED_PIN` in `pico-sdk\src\boards\include\boards\pico.h`) was 25.

You can still enable the drive activity light by putting something like
```
    add_compile_definitions(USE_LED=1)
```
in `CMakeLists.txt`, for example.