### PR TITLE
Disable drive activity LED by default (Pico W compatibility)

### DIFF
--- a/FatFs_SPI/sd_driver/spi.h
+++ b/FatFs_SPI/sd_driver/spi.h
@@ -69,19 +69,23 @@ void set_spi_dma_irq_channel(bool useChannel1, bool shared);
 }
 #endif
 
-#ifndef NO_PICO_LED
-#  define USE_LED 1
-#endif
+/* 
+This uses the Pico LED to show SD card activity.
+You can use it to get a rough idea of utilization.
+Warning: Pico W uses GPIO 25 for SPI communication to the CYW43439.
 
-#if USE_LED
-#  define LED_PIN 25
+You can enable this by putting something like
+    add_compile_definitions(USE_LED=1)
+in CMakeLists.txt, for example.
+*/
+#if !defined(NO_PICO_LED) && defined(USE_LED) && USE_LED && defined(PICO_DEFAULT_LED_PIN)
 #  define LED_INIT()                     \
     {                                    \
-        gpio_init(LED_PIN);              \
-        gpio_set_dir(LED_PIN, GPIO_OUT); \
+        gpio_init(PICO_DEFAULT_LED_PIN);              \
+        gpio_set_dir(PICO_DEFAULT_LED_PIN, GPIO_OUT); \
     }
-#  define LED_ON() gpio_put(LED_PIN, 1)
-#  define LED_OFF() gpio_put(LED_PIN, 0)
+#  define LED_ON() gpio_put(PICO_DEFAULT_LED_PIN, 1)
+#  define LED_OFF() gpio_put(PICO_DEFAULT_LED_PIN, 0)
 #else
 #  define LED_ON()
 #  define LED_OFF()

--- a/example/CMakeLists.txt
+++ b/example/CMakeLists.txt
@@ -29,6 +29,11 @@ target_link_libraries(FatFS_SPI_example pico_stdlib)
 
 target_compile_options(FatFS_SPI_example PUBLIC -Wall -Wextra -Wno-unused-function -Wno-unused-parameter)
 
+# Use Pico's LED to show drive activity. 
+# Ensure that PICO_DEFAULT_LED_PIN is set correctly.
+# Note that Pico W uses GPIO 25 for SPI communication to the CYW43439.
+# add_compile_definitions(USE_LED=1)
+
 pico_set_program_name(FatFS_SPI_example "FatFS_SPI_example")
 pico_set_program_version(FatFS_SPI_example "0.1")
 


### PR DESCRIPTION
For compatibility with Pico W, disable use of Pico LED by default.

The W uses GPIO 25 for SPI communication to the CYW43439.  In the old days, the Pico default LED pin (`PICO_DEFAULT_LED_PIN` in `pico-sdk\src\boards\include\boards\pico.h`) was 25.

You can still enable the drive activity light by putting something like
```
    add_compile_definitions(USE_LED=1)
```
in `CMakeLists.txt`, for example.

Relevant to #15 and #74